### PR TITLE
callblocker: do not crash if config.py does not have TELEGRAM_BOT_URL

### DIFF
--- a/a1fbox/callblocker.py
+++ b/a1fbox/callblocker.py
@@ -17,7 +17,10 @@ sys.path.append(os.path.dirname(__file__))
 from utils import Log, anonymize_number
 
 sys.path.append("..")
-from config import TELEGRAM_BOT_URL
+try:
+    from config import TELEGRAM_BOT_URL
+except ImportError:
+    TELEGRAM_BOT_URL = ""
 
 import requests
 


### PR DESCRIPTION
Small robustness improvement. If the user does not specify a
TELEGRAM_BOT_URL callblocker.py will not crash but just ignore
the setting.

I guess it's ultimately debatable if this is really needed. Feel free to just close if you feel the user should always have a complete config.